### PR TITLE
Fix Rest Timer Logic and Button Activation

### DIFF
--- a/lib/screens/resting_page.dart
+++ b/lib/screens/resting_page.dart
@@ -55,10 +55,10 @@ class RestingPageState extends State<RestingPage> with TickerProviderStateMixin 
 
     restTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
       setState(() {
-        accumulatedRestDuration = DateTime.now().difference(restStartTime!);
-        if (restDuration.inSeconds > accumulatedRestDuration.inSeconds) {
-          restDuration -= const Duration(seconds: 1);
-        } else {
+        final elapsedTime = DateTime.now().difference(restStartTime!) + accumulatedRestDuration;
+        restDuration = calculateRestDuration(widget.workDuration) - elapsedTime;
+
+        if (restDuration.isNegative || restDuration == Duration.zero) {
           restTimer?.cancel();
           isResting = false;
           restStarted = false;
@@ -88,10 +88,10 @@ class RestingPageState extends State<RestingPage> with TickerProviderStateMixin 
 
     restTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
       setState(() {
-        accumulatedRestDuration = DateTime.now().difference(restStartTime!) + accumulatedRestDuration;
-        if (restDuration.inSeconds > accumulatedRestDuration.inSeconds) {
-          restDuration -= const Duration(seconds: 1);
-        } else {
+        final elapsedTime = DateTime.now().difference(restStartTime!) + accumulatedRestDuration;
+        restDuration = calculateRestDuration(widget.workDuration) - elapsedTime;
+
+        if (restDuration.isNegative || restDuration == Duration.zero) {
           restTimer?.cancel();
           isResting = false;
           restStarted = false;
@@ -263,7 +263,7 @@ class RestingPageState extends State<RestingPage> with TickerProviderStateMixin 
                       ),
                       padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 24),
                     ),
-                    onPressed: isResting && !isRestPaused ? pauseResting : isRestPaused ? resumeResting : null,
+                    onPressed: restStarted && isResting && !isRestPaused ? pauseResting : isRestPaused ? resumeResting : null,
                     child: Text(
                       isRestPaused ? 'Resume' : 'Pause',
                       style: const TextStyle(


### PR DESCRIPTION
This pull request addresses the following issues:
1. The pause/resume button is now deactivated until the start button is pressed.
2. The timer logic is corrected to calculate the difference between the rest duration and the elapsed time correctly.

Closes #4 